### PR TITLE
Fix explodecomputer URL to MRCIEU URL

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,8 +1,8 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    # branches: [main, master]
+    branches: [main, master]
   pull_request:
     branches: [main, master]
 
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
@@ -29,18 +29,21 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,8 @@ Description: A convenient way to make binaries such as plink, bcftools,
     MRC IEU OpenGWAS system. The system includes other R packages,
     including; gwasglue, ieugwasr, gwasvcf, and TwoSampleMR.
 License: MIT + file LICENSE
-URL: https://github.com/explodecomputer/genetics.binaRies
-BugReports: https://github.com/explodecomputer/genetics.binaRies/issues
+URL: https://github.com/MRCIEU/genetics.binaRies
+BugReports: https://github.com/MRCIEU/genetics.binaRies/issues
 Imports:
     utils
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: genetics.binaRies
 Title: Binaries for Tools Used in Genetics in an R Package
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     c(person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
              comment = c(ORCID = "0000-0003-0920-1055")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,5 +19,5 @@ Suggests:
     testthat (>= 3.0.0)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Config/testthat/edition: 3

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,4 +3,3 @@
 export(get_bcftools_binary)
 export(get_gcta_binary)
 export(get_plink_binary)
-importFrom(utils,download.file)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# genetics.binaRies 0.1.0
+
+* Updated bcftools binary for Linux in source repo.
+
+* Modified `downloader()` to give the downloaded binary chmod 755 permissions.
+
 # genetics.binaRies 0.0.0.9000
 
 * Initial version of package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# genetics.binaRies 0.1.1
+
+* Updated several URLs to use the MRCIEU org repo address.
+
 # genetics.binaRies 0.1.0
 
 * Updated bcftools binary for Linux in source repo.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
 # genetics.binaRies 0.0.0.9000
 
+* Initial version of package.
+
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/get.r
+++ b/R/get.r
@@ -17,7 +17,6 @@ urlprefix <- list(urlprefix0, urlprefix1, urlprefix2, urlprefix3)
 is.error <- function(x) inherits(x, "try-error")
 
 # Function to check for and download executables
-#' @importFrom utils download.file
 downloader <- function(exename) {
   os <- Sys.info()[["sysname"]]
   dest <- file.path(system.file(package = "genetics.binaRies"), "bin")
@@ -34,7 +33,7 @@ downloader <- function(exename) {
         stop(exename, " not found at all ", length(urlprefix), " URLs.")
       }
       fullurl <- paste0(urlprefix[[i]], os, "/", exename)
-      err <- try(download.file(url = fullurl, destfile = destfile))
+      err <- try(utils::download.file(url = fullurl, destfile = destfile))
       if (!is.error(err)) download_success <- TRUE
       i <- i + 1L
     }

--- a/R/get.r
+++ b/R/get.r
@@ -2,13 +2,15 @@
 # i.e. - once PR accepted they'll be on Gib's master branch,
 # - until PR accepted they are on PR branch of my fork
 # - include my fork master branch as a fall back
+urlprefix0 <- paste0("https://github.com/MRCIEU/genetics.binaRies/",
+                     "raw/master/binaries/")
 urlprefix1 <- paste0("https://github.com/explodecomputer/genetics.binaRies/",
                      "raw/master/binaries/")
 urlprefix2 <- paste0("https://github.com/remlapmot/genetics.binaRies/",
                      "raw/cran-fixes-01-2022/binaries/")
 urlprefix3 <- paste0("https://github.com/remlapmot/genetics.binaRies/",
                      "raw/master/binaries/")
-urlprefix <- list(urlprefix1, urlprefix2, urlprefix3)
+urlprefix <- list(urlprefix0, urlprefix1, urlprefix2, urlprefix3)
 
 # Function to test for a try() error
 # from http://adv-r.had.co.nz/Exceptions-Debugging.html

--- a/R/get.r
+++ b/R/get.r
@@ -7,10 +7,8 @@ urlprefix0 <- paste0("https://github.com/MRCIEU/genetics.binaRies/",
 urlprefix1 <- paste0("https://github.com/explodecomputer/genetics.binaRies/",
                      "raw/master/binaries/")
 urlprefix2 <- paste0("https://github.com/remlapmot/genetics.binaRies/",
-                     "raw/cran-fixes-01-2022/binaries/")
-urlprefix3 <- paste0("https://github.com/remlapmot/genetics.binaRies/",
                      "raw/master/binaries/")
-urlprefix <- list(urlprefix0, urlprefix1, urlprefix2, urlprefix3)
+urlprefix <- list(urlprefix0, urlprefix1, urlprefix2)
 
 # Function to test for a try() error
 # from http://adv-r.had.co.nz/Exceptions-Debugging.html

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # genetics.binaRies
 
 <!-- badges: start -->
-[![R-CMD-check](https://github.com/explodecomputer/genetics.binaRies/workflows/R-CMD-check/badge.svg)](https://github.com/explodecomputer/genetics.binaRies/actions)
+[![R-CMD-check](https://github.com/MRCIEU/genetics.binaRies/workflows/R-CMD-check/badge.svg)](https://github.com/MRCIEU/genetics.binaRies/actions)
 <!-- badges: end -->
 
 The goal of genetics.binaRies is to provide a convenient way to make binaries 


### PR DESCRIPTION
Thanks to the work of @ritarasteiro on gwasvcf we spotted that it would be a good idea to change the last instances of the explodecomputer/genetics.binaRies URL to the MRCIEU/genetics.binaRies URL.

Also would it be possible for @ritarasteiro and myself to have maintainer permissions in this repo (one thing I'll then do is add a pkgdown site).

This also updates the R-cmd-check github action workflow.