### PR TITLE
Fix download mode for downloading exe files on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: genetics.binaRies
 Title: Binaries for Tools Used in Genetics in an R Package
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: 
     c(person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
              comment = c(ORCID = "0000-0003-0920-1055")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,5 +19,5 @@ Suggests:
     testthat (>= 3.0.0)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# genetics.binaRies 0.1.2
+
+* Windows .exe binaries are now downloaded using the correct mode.
+
 # genetics.binaRies 0.1.1
 
 * Updated several URLs to use the MRCIEU org repo address.

--- a/R/get.r
+++ b/R/get.r
@@ -31,7 +31,7 @@ downloader <- function(exename) {
         stop(exename, " not found at all ", length(urlprefix), " URLs.")
       }
       fullurl <- paste0(urlprefix[[i]], os, "/", exename)
-      err <- try(utils::download.file(url = fullurl, destfile = destfile))
+      err <- try(utils::download.file(url = fullurl, destfile = destfile, mode = "wb"))
       if (!is.error(err)) download_success <- TRUE
       i <- i + 1L
     }


### PR DESCRIPTION
It turns out that out downloads on Windows never worked because in `utils::download.file()` the `mode = "wb"` argument must be set when downloading binary files on Windows.

This explains and fixes what I thought was the mysterious error in #2.

Closes #2 